### PR TITLE
Rename packages and fix a couple of comment errors.

### DIFF
--- a/exercise/b-functions/Cargo.toml
+++ b/exercise/b-functions/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "b-functions"
+name = "b_functions"
 version = "0.1.0"
 authors = ["Nathan Stocks <nathan.stocks@gmail.com>"]
 edition = "2018"

--- a/exercise/d-control-flow-strings/Cargo.toml
+++ b/exercise/d-control-flow-strings/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "d-control-flow-strings"
+name = "d_control_flow_strings"
 version = "0.1.0"
 authors = ["Nathan Stocks <nathan.stocks@gmail.com>"]
 edition = "2018"

--- a/exercise/e-ownership-references/Cargo.toml
+++ b/exercise/e-ownership-references/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "e-ownership-references"
+name = "e_ownership_references"
 version = "0.1.0"
 authors = ["Nathan Stocks <nathan.stocks@gmail.com>"]
 edition = "2018"

--- a/exercise/f-structs-traits/Cargo.toml
+++ b/exercise/f-structs-traits/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "f-structs-traits"
+name = "f_structs_traits"
 version = "0.1.0"
 authors = ["Nathan Stocks <nathan.stocks@gmail.com>"]
 edition = "2018"

--- a/exercise/g-collections-enums/Cargo.toml
+++ b/exercise/g-collections-enums/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "g-collections-enums"
+name = "g_collections_enums"
 version = "0.1.0"
 authors = ["Nathan Stocks <nathan.stocks@gmail.com>"]
 edition = "2018"

--- a/exercise/h-closures-threads/Cargo.toml
+++ b/exercise/h-closures-threads/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "h-closures-threads"
+name = "h_closures_threads"
 version = "0.1.0"
 authors = ["Nathan Stocks <cleancut@github.com>"]
 edition = "2018"

--- a/exercise/h-closures-threads/src/main.rs
+++ b/exercise/h-closures-threads/src/main.rs
@@ -7,10 +7,10 @@ use std::time::Duration;
 fn expensive_sum(v: Vec<i32>) -> i32 {
     pause_ms(500);
     println!("Child thread: just about finished");
-    // 1a. Between the .iter() and the .sum() add a .filter() with a closure to remove any even
+    // 1a. Between the .iter() and the .sum() add a .filter() with a closure to keep any even
     // number (`x % 2` will be 0 for even numbers).
     // 1b. Between the .filter() and the .sum() add a .map() with a closure to square the values
-    // (multiple them by themselves)
+    // (multiply them by themselves)
     //
     // In the closures for both the .filter() and .map() the argument will be a reference, so you'll
     // either need to dereference the argument once in the parameter list like this: `|&x|` or you


### PR DESCRIPTION
Hello!

I have renamed the packages to their snake case name in order to comply with [RFC 940](https://rust-lang.github.io/rfcs/0940-hyphens-considered-harmful.html). 

Since that standard packages and crates containing hyphens in their name are not supported by the rust compiler but they are supported by Cargo.

If a student implements a function in the `src/lib.rs` file of any of these packages, then importing that function will produce a compile error that may cause confusion in the student. 

For example, in exercise E some students may choose to implement the function `inspect` in `src/lib.rs`. When trying to import this function in `src/main.rs` using the following use statement:
```
use e-ownership-references::inspect;
```
Will produce a compiler error:
```
error: expected one of `::`, `;`, or `as`, found `-`
 --> src/main.rs:4:6
  |
4 | use e-ownership-references::inspect;
  |      ^ expected one of `::`, `;`, or `as`

error: aborting due to previous error

error: could not compile `e-ownership-references`
```
Also quoting the package name will not resolve the issue as specified in [RFC 940](https://rust-lang.github.io/rfcs/0940-hyphens-considered-harmful.html).

The only way to solve this error is by replacing all the hyphens with `_` which may cause confusion among students.

I have also corrected a couple of comments in exercise H.

Great course BTW 😄 !