### PR TITLE
exercise-z: Update note for .grayscale()

### DIFF
--- a/exercise/z_final_project/src/main.rs
+++ b/exercise/z_final_project/src/main.rs
@@ -155,8 +155,7 @@ fn invert(infile: String, outfile: String) {
 fn grayscale(infile: String, outfile: String) {
     // See blur() for an example of how to open an image.
 
-    // .grayscale() takes no arguments and converts the image in-place, so
-    // you will use the same image to save out to a different file.
+    // .grayscale() takes no arguments. It returns a new image.
 
     // See blur() for an example of how to save the image.
 }


### PR DESCRIPTION
I come across this small TYPO in final exercise:

https://github.com/CleanCut/ultimate_rust_crash_course/blob/ccb6cd213bb8ce4a1ff2026e5113aa39b17d5fb7/exercise/z_final_project/src/main.rs#L158-L159

Based on official documentation ``.grayscale()`` returns a new image (please see [rust doc](https://docs.rs/image/0.19.0/image/enum.DynamicImage.html#method.grayscale))

```rust
pub fn grayscale(&self) -> DynamicImage { ... }
```

PS: Great course full of very useful tips and great exercises. Looking forward for your upcoming rust course.