### PR TITLE
Add vscode workspace

### DIFF
--- a/ultimate_rust_crash_course.code-workspace
+++ b/ultimate_rust_crash_course.code-workspace
@@ -1,0 +1,42 @@
+{
+	"folders": [
+		{
+			"name": "root",
+			"path": "./",
+
+		},
+		{
+			"path": "./examples/hello"
+		},
+		{
+			"path": "./exercise/a_variables"
+		},
+		{
+			"path": "./exercise/c_simple_types"
+		},
+		{
+			"path": "./exercise/d_control_flow_strings"
+		},
+		{
+			"path": "./exercise/e_ownership_references"
+		},
+		{
+			"path": "./exercise/f_structs_traits"
+		},
+		{
+			"path": "./exercise/g_collections_enums"
+		},
+		{
+			"path": "./exercise/h_closures_threads"
+		},
+		{
+			"path": "./exercise/z_final_project"
+		}
+	],
+	"settings": {
+		"files.exclude": {
+			"examples": true,
+			"exercise": true
+		  }
+	}
+}


### PR DESCRIPTION
The rust_analyser extension will display the error 'rust-analyzer failed to discover workspace' in vscode because it doesn't like many separate Rust projects in a single opened folder.

Added a workspace, if the cloner of this repo opens the workspace instead of the folder all projects will be properly parsed and analysed by Rust. 