### PR TITLE
Ignore unused variables in exercise e.

### DIFF
--- a/exercise/e_ownership_references/src/main.rs
+++ b/exercise/e_ownership_references/src/main.rs
@@ -1,5 +1,5 @@
 // Silence some warnings so they don't distract from the exercise.
-#![allow(unused_mut)]
+#![allow(unused_mut, unused_variables)]
 
 fn main() {
     // This fancy stuff either gets the first argument as a String, or prints


### PR DESCRIPTION
Not sure if you want this change but I get a compiler warning when running `cargo run` on this project before I start solving it. I noticed that we are disabling warnings for unused `mut` so figured we should be ignoring variables as well?

```
koddsson@Kristjans-MBP e_ownership_references % cargo run
   Compiling e_ownership_references v0.1.0 (/Users/koddsson/src/koddsson/ultimate_rust_crash_course/exercise/e_ownership_references)
warning: unused variable: `arg`
 --> src/main.rs:7:13
  |
7 |     let mut arg: String = std::env::args().nth(1).unwrap_or_else(|| {
  |             ^^^ help: if this is intentional, prefix it with an underscore: `_arg`
  |
  = note: `#[warn(unused_variables)]` on by default

warning: `e_ownership_references` (bin "e_ownership_references") generated 1 warning
    Finished dev [unoptimized + debuginfo] target(s) in 0.71s
     Running `target/debug/e_ownership_references`
Please supply an argument to this program.
```