### PR TITLE
Add workspace definition for rust-analyzer

### DIFF
--- a/exercise/Cargo.toml
+++ b/exercise/Cargo.toml
@@ -1,0 +1,11 @@
+[workspace]
+members = [
+    "b_functions",
+    "c_simple_types",
+    "d_control_flow_strings",
+    "e_ownership_references",
+    "f_structs_traits",
+    "g_collections_enums",
+    "h_closures_threads",
+    "z_final_project",
+]


### PR DESCRIPTION
Hey Nathan,
hope this PR finds you well.

A colleague is going through your course right now and has reached me for help regarding Rust-Analyzer.
They opened the `exercises` directory in VS-Code and struggled to get RA working for them.

I suggested they add a workspace definition to make it work, and I wondered if it's something that would interest you as well.

I have to admit that I have no idea if this impacts the learnability or degrades from the course's simplicity.
Also wasn't sure if it's right to add `a_variables`, since it doesn't contain a cargo project from the get-go.

Cheers,
Gilad