### PR TITLE
rename ownership references package to match exercise

### DIFF
--- a/exercise/g_ownership_references/Cargo.toml
+++ b/exercise/g_ownership_references/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "e_ownership_references"
+name = "g_ownership_references"
 version = "0.1.0"
 edition = "2021"
 


### PR DESCRIPTION
the exercise is located in `exercise/g_ownership_references/`, but the package referenced `e`. This corrects that.